### PR TITLE
회원가입 페이지 입장 버그 해결

### DIFF
--- a/src/main/java/com/example/gamePT/domain/user/request/SiteUserRequest.java
+++ b/src/main/java/com/example/gamePT/domain/user/request/SiteUserRequest.java
@@ -10,7 +10,6 @@ public class SiteUserRequest {
 
     @Getter
     @Setter
-    @Builder
     public static class Signup {
 
         @NotEmpty(message = "로그인 아이디를 입력해 주세요")


### PR DESCRIPTION
```

## 작업 내용
- 회원가입 페이지 입장시 java.lang.IllegalStateException: Cannot resolve parameter names for constructor 오류 출력 해결

## 변경 내용
- /domain/user/request/SiteUserRequest 클래스에서 Signup 클래스에 @Builder 어노테이션 삭제

## ISSUE 링크
- #15 

```
